### PR TITLE
Profile dummy info

### DIFF
--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -69,12 +69,12 @@ class _ProfilePageState extends State<ProfilePage> {
       children: [
         const SizedBox(height: 8),
         Text(
-          'Johnny Apppleseed',
+          'DJ Johnny Apppleseed',
           style: TextStyle(fontSize: 28, fontWeight: FontWeight.bold),
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: 2),
         Text(
-          'Description goes here',
+          'Artist',
           style: TextStyle(color: Colors.grey.shade700)
         ),
         const SizedBox(height: 20),
@@ -102,7 +102,7 @@ class _ProfilePageState extends State<ProfilePage> {
         color: Colors.transparent,
         child: InkWell(
           onTap: () {}, //does nothing at the moment
-          child: Center(child: Icon(icon, size: 30)),
+          child: Center(child: Icon(icon, size: 25)),
         ),
       ),
     );

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 class ProfilePage extends StatefulWidget
 {
@@ -10,28 +11,100 @@ class ProfilePage extends StatefulWidget
 
 
 class _ProfilePageState extends State<ProfilePage> {
+  final double coverHeight = 200;
+  final double profileHeight = 145;
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
+    
     return Scaffold(
-
-
-
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You are on the profile page!',
-            ),
-          ],
-        ),
+      body: ListView(
+        padding: EdgeInsets.zero,
+        children: <Widget>[
+          buildCoverAndProfile(),
+          buildContent(),
+        ],
       ),
     );
   }
+
+  Widget buildCoverAndProfile() {
+    final top = coverHeight - profileHeight /2;
+    final bottom = profileHeight / 2;
+
+    return Stack(
+      clipBehavior: Clip.none,
+      alignment: Alignment.center,
+      children: [
+        Container(
+          margin: EdgeInsets.only(bottom: bottom),
+          child: buildCoverImage(),
+        ),
+        Positioned(
+          top: top,
+          child: buildProfileImage()
+        ),
+      ],
+    );
+  }
+
+  Widget buildCoverImage() => Container(
+      color: Colors.grey,
+      child: Image.network(
+        'https://images.unsplash.com/photo-1485579149621-3123dd979885?w=1400&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTB8fG11c2ljfGVufDB8fDB8fHww',
+        width: double.infinity,
+        height: coverHeight,
+        fit: BoxFit.cover,
+      )
+    );
+
+    Widget buildProfileImage() => CircleAvatar(
+      radius: profileHeight / 2,
+      backgroundColor: Colors.grey,
+      backgroundImage: NetworkImage(
+        'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png'
+      )
+    );
+
+    Widget buildContent() => Column(
+      children: [
+        const SizedBox(height: 8),
+        Text(
+          'Johnny Apppleseed',
+          style: TextStyle(fontSize: 28, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Description goes here',
+          style: TextStyle(color: Colors.grey.shade700)
+        ),
+        const SizedBox(height: 20),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            buildSocialIcon(FontAwesomeIcons.spotify),
+            const SizedBox(width: 12),
+            buildSocialIcon(FontAwesomeIcons.apple),
+            const SizedBox(width: 12),
+            buildSocialIcon(FontAwesomeIcons.instagram),
+            const SizedBox(width: 12),
+            buildSocialIcon(FontAwesomeIcons.youtube),
+
+          ],
+        ),
+      ],
+    );
+
+    Widget buildSocialIcon(IconData icon) => CircleAvatar(
+      radius: 20,
+      child: Material(
+        shape: CircleBorder(),
+        clipBehavior: Clip.hardEdge,
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: () {}, //does nothing at the moment
+          child: Center(child: Icon(icon, size: 30)),
+        ),
+      ),
+    );
 }
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -136,6 +136,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  font_awesome_flutter:
+    dependency: "direct main"
+    description:
+      name: font_awesome_flutter
+      sha256: "1f93e5799f0e6c882819e8393a05c6ca5226010f289190f2242ec19f3f0fdba5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.0"
   http_parser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,9 @@ dependencies:
   firebase_auth: ^4.17.8
   firebase_core: ^2.27.0
 
+  # font awesome icons
+  font_awesome_flutter: ^9.1.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
# `profile_dummy_info`

## Changes
- A temporary cover page
    - got from unplash.com 
- A temporary profile picture
- A name
- A description to determine whether or not the user is an artist or listener
    - Got the icons from Font Awesome and added the library to the `pubspec` files
- Four icons that will act as links to the artist's social media pages (Spotify, Apple Music, Instagram, YouTube)
<img width="300" alt="Screenshot 2024-03-14 at 9 47 46 AM" src="https://github.com/DimitriGol/songbird/assets/92550481/3667d4a1-e66a-40cb-bb21-eb473534e7a2">

## Potential Issues/ Things to work on this page:
- [ ] Centering the icons in the circles 
- [ ] Adding areas where the artist's snippets would be (can just be `Placeholder()`s for now)
- [ ] Connecting the user's information to the profile
- [ ] Making another version of this screen for the listeners 
- [ ] Cleaning up code / adding documentation
- [ ] Font Awesome does not have an Apple Music icon, so it should be changed depending on what the group decides on
- [ ] Probably getting rid of the yellow bar on top, as it serves no purpose, and just having a settings button on the top right of the screen